### PR TITLE
Fix defaults for empty string default

### DIFF
--- a/utf8mb4-conversion.php
+++ b/utf8mb4-conversion.php
@@ -118,7 +118,7 @@ foreach ($tables as $table) {
         $name = $row[0];
         $type = $row[1];
         $allownull = (strtoupper($row[2]) == 'YES') ? 'NULL' : 'NOT NULL';
-        $defaultval = (trim($row[4]) == '') ? '' : "DEFAULT '{$row[4]}'";
+        $defaultval = (trim($row[4]) == '') ? "DEFAULT ' '" : "DEFAULT '{$row[4]}'";
         $set = false;
         if (preg_match("/^varchar\((\d+)\)$/i", $type, $matches)) {
             $size = $matches[1];

--- a/utf8mb4-conversion.php
+++ b/utf8mb4-conversion.php
@@ -118,7 +118,7 @@ foreach ($tables as $table) {
         $name = $row[0];
         $type = $row[1];
         $allownull = (strtoupper($row[2]) == 'YES') ? 'NULL' : 'NOT NULL';
-        $defaultval = (trim($row[4]) == '') ? '' : "DEFAULT '{$row[4]}'";
+        $defaultval = (trim($row[4]) == '') ? "DEFAULT ''" : "DEFAULT '{$row[4]}'";
         $set = false;
         if (preg_match("/^varchar\((\d+)\)$/i", $type, $matches)) {
             $size = $matches[1];


### PR DESCRIPTION
The current code mis-interprets 

DEFAULT ' '

as "no default".  You can see that by converting the admin table.  The field prev_pass1 goes from 

prev_pass1 varchar(255) NOT NULL default '',

TO

prev_pass1 varchar(255) NOT NULL; 

(i.e. with no default value).  This in turn causes issues for installations in strict mode. 

